### PR TITLE
Fix trap warning - no longer creates temp scriptableObject

### DIFF
--- a/Assets/Scripts/Gamplay/TrapManager.cs
+++ b/Assets/Scripts/Gamplay/TrapManager.cs
@@ -20,16 +20,16 @@ public class TrapManager : Singleton<TrapManager>
         return trap;
     }
 
-    public void SaveTrap(TrapScriptable newTrap) {
+    public void SaveTrap(string id, Color backColor, Color headColor, Color eyesColor) {
         bool found = false;
 
         int i = 0;
         while (i < gameData.traps.Count && !found) {
             if (gameData.traps[i].id == "") {
-                gameData.traps[i].id = newTrap.id;
-                gameData.traps[i].backColor = newTrap.backColor;
-                gameData.traps[i].headColor = newTrap.headColor;
-                gameData.traps[i].eyesColor = newTrap.eyesColor;
+                gameData.traps[i].id = id;
+                gameData.traps[i].backColor = backColor;
+                gameData.traps[i].headColor = headColor;
+                gameData.traps[i].eyesColor = eyesColor;
                 found = true;
             }
             i++;

--- a/Assets/Scripts/Scenario/Trap.cs
+++ b/Assets/Scripts/Scenario/Trap.cs
@@ -22,7 +22,9 @@ public class Trap : MonoBehaviour
         }
 
         trapCollider = GetComponent<Collider2D>();
+    }
 
+    private void Start() {
         LoadTrapData();
     }
 
@@ -44,14 +46,7 @@ public class Trap : MonoBehaviour
         if (collision.gameObject.layer == (int)Layers.Player) {
             PlayerColor playerColor = collision.gameObject.GetComponent<PlayerColor>();
             Color[] colors = playerColor.GetColors();
-
-            TrapScriptable trapData = new TrapScriptable();
-            trapData.id = id;
-            trapData.backColor = colors[0];
-            trapData.headColor = colors[1];
-            trapData.eyesColor = colors[2];
-
-            TrapManager.Instance.SaveTrap(trapData);
+            TrapManager.Instance.SaveTrap(id, colors[0], colors[1], colors[2]);
 
             // TODO: KILL PLAYER
             SceneManager.LoadScene((int)Scenes.TutorialLevel);


### PR DESCRIPTION
Botava un warning perquè feia un "new ScriptableObject".
He canviat el codi per no necessitar crear l'element temporal.